### PR TITLE
Add build to nvim-typescript (fixes #1800)

### DIFF
--- a/autoload/SpaceVim/layers/lang/typescript.vim
+++ b/autoload/SpaceVim/layers/lang/typescript.vim
@@ -12,7 +12,7 @@ function! SpaceVim#layers#lang#typescript#plugins() abort
   call add(plugins, ['leafgarland/typescript-vim'])
   if !SpaceVim#layers#lsp#check_filetype('typescript')
     if has('nvim')
-      call add(plugins, ['mhartington/nvim-typescript'])
+      call add(plugins, ['mhartington/nvim-typescript', {'build': './install.sh'}])
     else
       call add(plugins, ['Quramy/tsuquyomi'])
     endif

--- a/wiki/en/Following-HEAD.md
+++ b/wiki/en/Following-HEAD.md
@@ -61,6 +61,7 @@ The next release is v0.9.0.
 - can not set `windows_leader` to empty string ([#1990](https://github.com/SpaceVim/SpaceVim/pull/1990))
 - Setting 'verbose' flag to positive value breaks mappings guides ([#2017](https://github.com/SpaceVim/SpaceVim/pull/2017))
 - Fix whitespace toggle ([#2032](https://github.com/SpaceVim/SpaceVim/pull/2032))
+- Fix Unknown function: TSOnBufEnter for nvim-typescript ([#2062](https://github.com/SpaceVim/SpaceVim/pull/2062))
 
 ### Removed
 


### PR DESCRIPTION
Looking at the official documentation for `nvim-typescript`, it says to add {'build': './install.sh'}
https://github.com/mhartington/nvim-typescript/blob/master/README.md

After making this simple change (and clearing ~/.cache/vimfiles). It started working as expected. No idea why it was still working for some people and not others

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I have updated the [Following-HEAD](https://github.com/SpaceVim/SpaceVim/blob/master/wiki/en/Following-HEAD.md) page for this PR.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]

It fixes issue https://github.com/SpaceVim/SpaceVim/issues/1800
As said in the git commit. It updates the plugin to install the dependencies and build the typescript files inside nvim-typescript (as per [the official documentation for nvim-typescript](https://github.com/mhartington/nvim-typescript/blob/master/README.md))

I don't exactly know how someone would make a unit/integration test for something like this