### PR TITLE
Fixing doc "SpaceVim lang#html layer".

### DIFF
--- a/docs/layers/lang/html.md
+++ b/docs/layers/lang/html.md
@@ -43,7 +43,7 @@ npm install --global vscode-html-languageserver-bin
 - `emmet_filetyps`: Set the filetypes for enabling emmet
 
   ```toml
-  [layers]
+  [[layers]]
     name = "lang#html"
     emmet_leader_key = "<C-e>"
     emmet_filetyps = ['html']


### PR DESCRIPTION
in the url  below:
https://spacevim.org/layers/lang/html/

In the part of "layer options" it shows:
  ```[layer]```
with simple square brakets. But they must be double or it produces error:
"required list"

fix with this:
  ```[[layers]]```

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

[Please explain **in detail** why the changes in this PR are needed.]
