### PR TITLE
Fix enable_indentline field in the ui layer

### DIFF
--- a/bundle/indent-blankline.nvim/lua/indent_blankline/utils.lua
+++ b/bundle/indent-blankline.nvim/lua/indent_blankline/utils.lua
@@ -65,7 +65,7 @@ M.is_indent_blankline_enabled =
         if b_enabled ~= nil then
             return b_enabled
         end
-        if g_enabled == false then
+        if g_enabled == 0 then
             return false
         end
 


### PR DESCRIPTION
use `g_enabled == 0` to fix `enable_indentline = false` behaviour in the ui layer.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

The bundled version of indent-blankline checks `g_enabled == false` to decide whether the user wants to disable this feature on the fly. This does not work well with how SpaceVim parse the toml and how neovim serialize boolean values into msgpack. Currently the `g_enabled` (derived directly from `g:indent_blankline_enabled`, and at the end of the day, `s:enable_indentline` set by toml) will always be an int, hence the condition `g_enabled == false` would never be true, making the enable_indentline field (especially when the value is false in toml) usless.

Ideally it would be nice to parse toml boolean value as v:true and v:false, but I could image that would be another compatibility disaster.