### PR TITLE
fix(lang#python): fix typo in the coverage key bindings

### DIFF
--- a/autoload/SpaceVim/layers/lang/python.vim
+++ b/autoload/SpaceVim/layers/lang/python.vim
@@ -193,19 +193,19 @@ function! s:language_specified_mappings() abort
 
   call SpaceVim#mapping#space#langSPC('nmap', ['l','c', 'r'],
         \ 'Coveragepy report',
-        \ 'coverager eport', 1)
+        \ 'coverage report', 1)
 
   call SpaceVim#mapping#space#langSPC('nmap', ['l','c', 's'],
         \ 'Coveragepy show',
-        \ 'coverager show', 1)
+        \ 'coverage show', 1)
 
   call SpaceVim#mapping#space#langSPC('nmap', ['l','c', 'e'],
         \ 'Coveragepy session',
-        \ 'coverager session', 1)
+        \ 'coverage session', 1)
 
   call SpaceVim#mapping#space#langSPC('nmap', ['l','c', 'f'],
         \ 'Coveragepy refresh',
-        \ 'coverager refresh', 1)
+        \ 'coverage refresh', 1)
 
   " +Generate {{{
 

--- a/docs/cn/layers/lang/python.md
+++ b/docs/cn/layers/lang/python.md
@@ -174,10 +174,10 @@ pip install --user coverage
 
 | 模式   | 快捷键      | 功能描述          |
 | ------ | ----------- | ----------------- |
-| normal | `SPC l c r` | coverager report  |
-| normal | `SPC l c s` | coverager show    |
-| normal | `SPC l c e` | coverager session |
-| normal | `SPC l c f` | coverager refresh |
+| normal | `SPC l c r` | coverage report  |
+| normal | `SPC l c s` | coverage show    |
+| normal | `SPC l c e` | coverage session |
+| normal | `SPC l c f` | coverage refresh |
 
 ### 交互式编程
 

--- a/docs/layers/lang/python.md
+++ b/docs/layers/lang/python.md
@@ -168,10 +168,10 @@ you need to add following snippet into your spacevim configuration file.
 
 | Mode   | Key Binding | Description       |
 | ------ | ----------- | ----------------- |
-| normal | `SPC l c r` | coverager report  |
-| normal | `SPC l c s` | coverager show    |
-| normal | `SPC l c e` | coverager session |
-| normal | `SPC l c f` | coverager refresh |
+| normal | `SPC l c r` | coverage report  |
+| normal | `SPC l c s` | coverage show    |
+| normal | `SPC l c e` | coverage session |
+| normal | `SPC l c f` | coverage refresh |
 
 ### Text objects and motions
 


### PR DESCRIPTION
Fixed misspelled key binding descriptions.

### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

Descriptions for the coverage key bindings in the python layer were misspelled.