### PR TITLE
fix: set default font correctly on macOS

### DIFF
--- a/lua/spacevim/api/system.lua
+++ b/lua/spacevim/api/system.lua
@@ -27,7 +27,7 @@ end
 
 local M = {}
 
-if has('win16') ==1 or has('win32') == 1 or has('win64') == 1 then
+if has('win16') == 1 or has('win32') == 1 or has('win64') == 1 then
     M.isWindows = 1
 else
     M.isWindows = 0

--- a/lua/spacevim/default.lua
+++ b/lua/spacevim/default.lua
@@ -35,9 +35,9 @@ function M.options()
             )
         end
 
-        if SYSTEM.isWindows then
+        if SYSTEM.isWindows == 1 then
             guifont = "DejaVu_Sans_Mono_for_Powerline:h11:cANSI:qDRAFT"
-        elseif SYSTEM.isOSX then
+        elseif SYSTEM.isOSX == 1 then
             guifont = "DejaVu Sans Mono for Powerline:h11"
         else
             guifont = "DejaVu Sans Mono for Powerline 11"


### PR DESCRIPTION
### PR Prelude

Thank you for working on SpaceVim! :)

Please complete these steps and check these boxes before filing your PR:

- [x] I have read and understood SpaceVim's [CONTRIBUTING](https://github.com/SpaceVim/SpaceVim/blob/master/CONTRIBUTING.md) document.
- [x] I have read and understood SpaceVim's [CODE_OF_CONDUCT](https://github.com/SpaceVim/SpaceVim/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.

### Why this change is necessary and useful?

the problem here is that in Lua, `0` is truthy (see
https://www.lua.org/pil/2.2.html).  as a result, in
`lua/spacevim/default.lua`:

```lua
if SYSTEM.isWindows then
  ...
```

was always triggering, even when `SYSTEM.isWindows = 0`, which resulted
in an invalid default value for `guifont` on macOS.

a better fix would probably be to refactor `SYSTEM.isWindows`,
`SYSTEM.isLinux`, and `SYSTEM.isOSX` such that they are booleans rather
than numbers, i'll consider tackling that later, but this patch fixes
the immediate problem.

